### PR TITLE
chore: header px 조정 및 main, nav 위치 변경

### DIFF
--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+
 import Header from "@/components/organisms/Header";
 import Content from "@/components/organisms/Content";
 
@@ -8,13 +10,18 @@ interface ServiceLayoutProps {
 const ServiceLayout = ({ children }: Readonly<ServiceLayoutProps>) => {
   return (
     <div className="flex flex-col h-full">
-      <header className="flex justify-center px-4 border-b border-service-gray-medium">
+      <header
+        className={clsx(
+          "flex justify-center border-b border-service-gray-medium",
+          "px-4 md:px-6"
+        )}
+      >
         <Header />
       </header>
 
-      <main className="flex flex-1 justify-center">
+      <div className="flex flex-1 justify-center">
         <Content>{children}</Content>
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/components/organisms/Content.tsx
+++ b/src/components/organisms/Content.tsx
@@ -18,7 +18,7 @@ const Content = ({ children }: Readonly<ConetentProps>) => {
         <SideNav />
       </nav>
 
-      <div className="flex-1 p-4">{children}</div>
+      <main className="flex-1 p-4">{children}</main>
     </div>
   );
 };


### PR DESCRIPTION
## 📌 작업 개요

- header px 조정 및 main 요소 위치 하위 계층으로 이동

## ✨ 주요 변경사항

- header padding을 모바일에서는 px-4, 태블릿 이상에서는 px-6으로 조정
- ServiceLayout 컴포넌트에 위치했던 main 요소를 Content 컴포넌트로 이동하여 계층 구조 조정

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- (리뷰어가 알아야 할 추가 정보, 고려사항, 후속 작업 TODO 등)

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
