### PR TITLE
chore: 버튼 폰트 스타일 및 오타 수정

### DIFF
--- a/src/components/atoms/button/PrimaryButton.tsx
+++ b/src/components/atoms/button/PrimaryButton.tsx
@@ -2,9 +2,10 @@
 
 import clsx from "clsx";
 
+import Label1 from "@/components/atoms/typography/Label1";
 import ButtonProps from "@/components/atoms/button/props/buttonProps";
 
-const PrimaryButton = ({ label, disbled = false, onClick }: ButtonProps) => {
+const PrimaryButton = ({ label, disabled = false, onClick }: ButtonProps) => {
   return (
     <button
       className={clsx(
@@ -13,13 +14,12 @@ const PrimaryButton = ({ label, disbled = false, onClick }: ButtonProps) => {
         "md:px-4",
         "rounded-lg",
         "bg-primary",
-        "text-md md:text-lg",
+        "text-base",
         "font-semibold",
         "text-white",
-        "cursor-pointer",
-        "disabled:bg-service-gray-medium disabled:text-service-gray disabled:cursor-not-allowed"
+        "disabled:bg-service-gray-medium disabled:text-service-gray"
       )}
-      disabled={disbled}
+      disabled={disabled}
       onClick={onClick}
     >
       {label}

--- a/src/components/atoms/button/SecondaryButton.tsx
+++ b/src/components/atoms/button/SecondaryButton.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 
 import ButtonProps from "@/components/atoms/button/props/buttonProps";
 
-const SecondaryButton = ({ label, disbled = false, onClick }: ButtonProps) => {
+const SecondaryButton = ({ label, disabled = false, onClick }: ButtonProps) => {
   return (
     <button
       className={clsx(
@@ -13,13 +13,12 @@ const SecondaryButton = ({ label, disbled = false, onClick }: ButtonProps) => {
         "md:px-4",
         "rounded-lg",
         "bg-service-gray-medium",
-        "text-md md:text-lg",
+        "text-base",
         "font-semibold",
-        "text-service-black",
-        "cursor-pointer",
-        "disabled:bg-service-gray-medium disabled:text-service-gray disabled:cursor-not-allowed"
+        "text-white",
+        "disabled:bg-service-gray-medium disabled:text-service-gray"
       )}
-      disabled={disbled}
+      disabled={disabled}
       onClick={onClick}
     >
       {label}

--- a/src/components/atoms/button/TertiaryButton.tsx
+++ b/src/components/atoms/button/TertiaryButton.tsx
@@ -12,7 +12,7 @@ interface TertiaryButtonProps extends ButtonProps {
 const TertiaryButton = ({
   label,
   styles,
-  disbled = false,
+  disabled = false,
   onClick,
 }: TertiaryButtonProps) => {
   return (
@@ -21,13 +21,12 @@ const TertiaryButton = ({
         "w-full md:w-auto",
         "h-12",
         "md:px-4",
-        "text-md md:text-lg",
+        "text-base",
         "font-semibold",
         styles?.labelColor ?? "text-service-black",
-        "cursor-pointer",
-        "disabled:text-service-gray disabled:cursor-not-allowed"
+        "disabled:text-service-gray"
       )}
-      disabled={disbled}
+      disabled={disabled}
       onClick={onClick}
     >
       {label}

--- a/src/components/atoms/button/props/buttonProps.ts
+++ b/src/components/atoms/button/props/buttonProps.ts
@@ -1,5 +1,5 @@
 export default interface ButtonProps {
   label: string;
-  disbled?: boolean;
+  disabled?: boolean;
   onClick: () => void;
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -35,6 +35,14 @@
     white-space: pre-line;
   }
 
+  button {
+    cursor: pointer;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+
   img,
   picture,
   video,


### PR DESCRIPTION
## 📌 작업 개요

- 버튼 폰트 스타일 수정
- disabled props 오타 수정
- cursor event 글로벌화

## ✨ 주요 변경사항

- reset.css에 버튼의 cursor: pointer 스타일 추가 및 disable 상태에서 cursor: not-allowed 스타일 적용
- 버튼 컴포넌트의 disabled props 오타 수정 (disbled -> disabled)
- 버튼 라벨 폰트 크기 base로 변경

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- 이후 추가될 버튼 라벨 크기는 기본 base로 통일

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
