### PR TITLE
refactor: 태블릿 사이즈 side nav 폭 조정

### DIFF
--- a/src/components/organisms/SideNav.tsx
+++ b/src/components/organisms/SideNav.tsx
@@ -1,8 +1,14 @@
 import NavLinkGroup from "@/components/molecules/NavLinkGroup";
+import clsx from "clsx";
 
 const SideNav = () => {
   return (
-    <div className="flex flex-col justify-between items-center w-52 h-full">
+    <div
+      className={clsx(
+        "flex flex-col justify-between items-center h-full",
+        "w-36 lg:w-52"
+      )}
+    >
       <NavLinkGroup />
     </div>
   );


### PR DESCRIPTION
## 📌 작업 개요

- 태블릿 사이즈 side nav 폭 조정

## ✨ 주요 변경사항

- side nav w-52 -> w-36 lg:w-52로 변경

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- X

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
