### PR TITLE
refactor: 현재 경로에 해당하는 Nav 버튼 색상 변경 및 모바일 Nav 탭 이동 시 자동 닫힘 처리

### DIFF
--- a/src/components/atoms/NavLink.tsx
+++ b/src/components/atoms/NavLink.tsx
@@ -5,9 +5,10 @@ interface NavLinkProps {
   label: string;
   to: string;
   isActive: boolean;
+  onClick?: () => void;
 }
 
-const NavLink = ({ label, to, isActive }: NavLinkProps) => {
+const NavLink = ({ label, to, isActive, onClick }: NavLinkProps) => {
   return (
     <Link
       className={clsx(
@@ -15,6 +16,7 @@ const NavLink = ({ label, to, isActive }: NavLinkProps) => {
         isActive && "text-primary"
       )}
       href={to}
+      onClick={onClick}
     >
       {label}
     </Link>

--- a/src/components/molecules/NavLinkGroup.tsx
+++ b/src/components/molecules/NavLinkGroup.tsx
@@ -1,13 +1,33 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
 import NavLink from "@/components/atoms/NavLink";
 
-const NavLinkGroup = () => {
+const links: { label: string; to: string }[] = [
+  { label: "오늘의 수확", to: "/insight/today" },
+  { label: "오늘의 타작", to: "/question/today" },
+  { label: "수확물 창고", to: "/insight/storage" },
+];
+
+interface NavLinkGroupProps {
+  onLinkClick?: () => void;
+}
+
+const NavLinkGroup = ({ onLinkClick }: NavLinkGroupProps) => {
+  const pathname: string = usePathname();
+
   return (
     <div className="flex flex-col w-full">
-      <NavLink label="오늘의 수확" to="/insight/today" isActive={true} />
-
-      <NavLink label="오늘의 타작" to="/question/today" isActive={false} />
-
-      <NavLink label="수확물 창고" to="/insight/storage" isActive={false} />
+      {links.map(({ label, to }, index) => (
+        <NavLink
+          key={index}
+          label={label}
+          to={to}
+          isActive={pathname === to}
+          onClick={onLinkClick}
+        />
+      ))}
     </div>
   );
 };

--- a/src/components/organisms/OverlayNav.tsx
+++ b/src/components/organisms/OverlayNav.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { FiX } from "react-icons/fi";
 
 import { SVG_SIZE } from "@/lib/constants/ui";
@@ -17,7 +15,7 @@ const OverlayNav = ({ onClose }: OverlayNavProps) => {
         <FiX size={SVG_SIZE} onClick={() => onClose(false)} />
       </div>
 
-      <NavLinkGroup />
+      <NavLinkGroup onLinkClick={() => onClose(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## 📌 작업 개요

- 현재 경로에 해당하는 Nav 버튼 색상 변경 및 모바일 Nav 탭 이동 시 자동 닫힘 처리

## ✨ 주요 변경사항

- NavLink 컴포넌트 props에 OnClick 추가
- 라우트명 및 경로 객체화
- 모바일 버전 페이지 이동시 nav 자동 닫힘
- 현재 경로에 해당하는 Nav 버튼 색상 변경

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- 다른 경로 추가시 components/molecules/NavLinkGroup.tsx의 links 객체에 추가

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
