### PR TITLE
feat: interceptor 파라미터 변경 및 jwt interceptor, reissue token intercepto…

### DIFF
--- a/src/lib/apis/interceptors/request/requestInterceptor.ts
+++ b/src/lib/apis/interceptors/request/requestInterceptor.ts
@@ -1,3 +1,5 @@
+import { RequestConfig } from "@/lib/apis/types/config";
+
 export default interface RequestInterceptor {
-  (request: Request): Request | Promise<Request>;
+  (config: RequestConfig): RequestConfig | Promise<RequestConfig>;
 }

--- a/src/lib/apis/interceptors/request/withAccessTokenInterceptor.ts
+++ b/src/lib/apis/interceptors/request/withAccessTokenInterceptor.ts
@@ -1,0 +1,26 @@
+import { getAccessTokenFromCookie } from "@/lib/cookie/accessToken";
+import { RequestConfig } from "@/lib/apis/types/config";
+import RequestInterceptor from "@/lib/apis/interceptors/request/requestInterceptor";
+
+const withAccessTokenInterceptor: RequestInterceptor = async (config: RequestConfig) => {
+  const { url, init = {} } = config;
+  const accessToken: string | null = await getAccessTokenFromCookie();
+  if (!accessToken) {
+    return config;
+  }
+
+  const headers: Headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${accessToken}`);
+
+  const authorizedConfig: RequestConfig = {
+    url,
+    init: {
+      ...init,
+      headers,
+    },
+  };
+
+  return authorizedConfig;
+};
+
+export default withAccessTokenInterceptor;

--- a/src/lib/apis/interceptors/request/withRefreshTokenInterceptor.ts
+++ b/src/lib/apis/interceptors/request/withRefreshTokenInterceptor.ts
@@ -1,0 +1,26 @@
+import { getRefreshTokenFromCookie } from "@/lib/cookie/refreshToken";
+import { RequestConfig } from "@/lib/apis/types/config";
+import RequestInterceptor from "@/lib/apis/interceptors/request/requestInterceptor";
+
+const withRefreshTokenInterceptor: RequestInterceptor = async (config: RequestConfig) => {
+  const { url, init = {} } = config;
+  const refreshToken: string | null = await getRefreshTokenFromCookie();
+  if (!refreshToken) {
+    return config;
+  }
+
+  const headers: Headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${refreshToken}`);
+
+  const authorizedConfig: RequestConfig = {
+    url,
+    init: {
+      ...init,
+      headers,
+    },
+  };
+
+  return authorizedConfig;
+};
+
+export default withRefreshTokenInterceptor;

--- a/src/lib/apis/interceptors/response/reissueTokenInterceptor.ts
+++ b/src/lib/apis/interceptors/response/reissueTokenInterceptor.ts
@@ -1,0 +1,40 @@
+import { getAccessTokenFromCookie } from "@/lib/cookie/accessToken";
+import { RequestConfig } from "@/lib/apis/types/config";
+import ResponseInterceptor from "@/lib/apis/interceptors/response/responseInterceptor";
+
+import reissueToken from "@/domains/auth/usecases/reissueToken";
+
+const reissueTokenInterceptor: ResponseInterceptor = async (config: RequestConfig, response: Response): Promise<Response> => {
+  if (response.status !== 401) {
+    return response;
+  }
+
+  const { url, init = {} } = config;
+
+  try {
+    await reissueToken();
+
+    const accessToken: string | null = await getAccessTokenFromCookie();
+    if (!accessToken) {
+      return response;
+    }
+
+    const headers: Headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+
+    const authorizedInit: RequestInit = {
+      ...init,
+      headers,
+    };
+
+    const retryRequest: Request = new Request(url, authorizedInit);
+
+    const retriedResponse: Response = await fetch(retryRequest);
+
+    return retriedResponse;
+  } catch (e) {
+    return response;
+  }
+};
+
+export default reissueTokenInterceptor;

--- a/src/lib/apis/interceptors/response/responseInterceptor.ts
+++ b/src/lib/apis/interceptors/response/responseInterceptor.ts
@@ -1,3 +1,5 @@
+import { RequestConfig } from "@/lib/apis/types/config";
+
 export default interface ResponseInterceptor {
-  (request: Request, response: Response): Response | Promise<Response>;
+  (config: RequestConfig, response: Response): Response | Promise<Response>;
 }

--- a/src/lib/apis/types/config.ts
+++ b/src/lib/apis/types/config.ts
@@ -1,0 +1,4 @@
+export interface RequestConfig {
+  url: string;
+  init?: RequestInit;
+}


### PR DESCRIPTION
…r 구현

## 📌 작업 개요

- interceptor 파라미터 변경 및 인증 인가 관련 interceptor 구현

## ✨ 주요 변경사항

- request interceptor 파라미터 Request -> RequestConfig로 변경
- response interceptor 파라미터 Request -> RequestConfig로 변경
- lib/apis/interceptors에 jwt 및 토큰 재발급 interceptor 구현

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- server action에서 jwt를 가져오는 대신 interceptor 사용
- 토큰 자동 재발급이 필요한 요청은 reissueTokenInterceptor 사용

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
