### PR TITLE
chore: 에러 클래스 property 수정 및 각 도메인 별 에러 메세지 상수화

### DIFF
--- a/src/domains/auth/constants/errorMessage.ts
+++ b/src/domains/auth/constants/errorMessage.ts
@@ -1,0 +1,7 @@
+export const KAKAO_LOGIN_ERROR: string = "카카오 로그인 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.";
+export const KAKAO_USER_NOT_FOUND_ERROR: string = "카카오 사용자 정보를 불러오는데 실패했어요. 잠시 후 다시 시도해 주세요.";
+
+export const AUTH_EXPIRED_ERROR: string = "인증이 만료되었어요. 다시 로그인해 주세요.";
+
+export const MEMBER_NOT_FOUND_ERROR: string = "존재하지 않는 사용자에요.";
+export const MEMBER_CONFLICT_ERROR: string = "이미 가입된 사용자에요. 다른 방법으로 로그인해 주세요.";

--- a/src/domains/auth/datasources/kakaoAccountSource.ts
+++ b/src/domains/auth/datasources/kakaoAccountSource.ts
@@ -1,6 +1,7 @@
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
 import { KAKAO_ACCOUNT_URL } from "@/domains/auth/constants/url";
+import { KAKAO_LOGIN_ERROR, KAKAO_USER_NOT_FOUND_ERROR } from "@/domains/auth/constants/errorMessage";
 import { KakaoAccountResDto } from "@/domains/auth/dtos/response/kakaoAccountResDto";
 
 const kakaoAccountSource = async (kakaoToken: string): Promise<KakaoAccountResDto> => {
@@ -14,8 +15,8 @@ const kakaoAccountSource = async (kakaoToken: string): Promise<KakaoAccountResDt
       },
     },
     errorMessage: {
-      400: "카카오 로그인 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.",
-      401: "카카오 사용자 정보를 불러오는데 실패했어요. 잠시 후 다시 시도해 주세요.",
+      400: KAKAO_LOGIN_ERROR,
+      401: KAKAO_USER_NOT_FOUND_ERROR,
     },
   });
 

--- a/src/domains/auth/datasources/kakaoTokenSource.ts
+++ b/src/domains/auth/datasources/kakaoTokenSource.ts
@@ -1,6 +1,7 @@
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
 import { KAKAO_TOKEN_URL } from "@/domains/auth/constants/url";
+import { KAKAO_LOGIN_ERROR, KAKAO_USER_NOT_FOUND_ERROR } from "@/domains/auth/constants/errorMessage";
 import { KakaoTokenResDto } from "@/domains/auth/dtos/response/kakaoTokenResDto";
 
 const kakaoTokenSource = async (kakaoCode: string): Promise<KakaoTokenResDto> => {
@@ -19,8 +20,8 @@ const kakaoTokenSource = async (kakaoCode: string): Promise<KakaoTokenResDto> =>
       }),
     },
     errorMessage: {
-      400: "카카오 로그인 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.",
-      401: "카카오 사용자 정보를 불러오는데 실패했어요. 잠시 후 다시 시도해 주세요.",
+      400: KAKAO_LOGIN_ERROR,
+      401: KAKAO_USER_NOT_FOUND_ERROR,
     },
   });
 

--- a/src/domains/auth/datasources/reissueTokenSource.ts
+++ b/src/domains/auth/datasources/reissueTokenSource.ts
@@ -2,6 +2,7 @@ import { buildApiServerUrl } from "@/lib/utils/url";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 import ApiResponse from "@/lib/models/apiResponse";
 
+import { AUTH_EXPIRED_ERROR } from "@/domains/auth/constants/errorMessage";
 import { ReissueTokenResDto } from "@/domains/auth/dtos/response/reissueTokenResDto";
 
 const reissueTokenSource = async (refreshToken: string): Promise<ApiResponse<ReissueTokenResDto>> => {
@@ -16,7 +17,7 @@ const reissueTokenSource = async (refreshToken: string): Promise<ApiResponse<Rei
       },
     },
     errorMessage: {
-      401: "인증이 만료되었어요. 다시 로그인 해주세요.",
+      401: AUTH_EXPIRED_ERROR,
     },
   });
 

--- a/src/domains/auth/datasources/signInSource.ts
+++ b/src/domains/auth/datasources/signInSource.ts
@@ -3,6 +3,7 @@ import { CONTENT_TYPE_JSON } from "@/lib/apis/constants/contentType";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 import ApiResponse from "@/lib/models/apiResponse";
 
+import { MEMBER_NOT_FOUND_ERROR } from "@/domains/auth/constants/errorMessage";
 import { SignInReqDto } from "@/domains/auth/dtos/request/signInReqDto";
 import { SignInResDto } from "@/domains/auth/dtos/response/signInResDto";
 
@@ -17,6 +18,9 @@ const signInSource = async (body: SignInReqDto): Promise<ApiResponse<SignInResDt
         "Content-type": CONTENT_TYPE_JSON,
       },
       body: JSON.stringify(body),
+    },
+    errorMessage: {
+      401: MEMBER_NOT_FOUND_ERROR,
     },
   });
 

--- a/src/domains/auth/datasources/signOutSource.ts
+++ b/src/domains/auth/datasources/signOutSource.ts
@@ -1,6 +1,8 @@
 import { buildApiServerUrl } from "@/lib/utils/url";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
+import { MEMBER_NOT_FOUND_ERROR } from "@/domains/auth/constants/errorMessage";
+
 const signOutSource = async (accessToken: string): Promise<void> => {
   const endpoint: string = "auth/sign-out";
 
@@ -11,6 +13,9 @@ const signOutSource = async (accessToken: string): Promise<void> => {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
+    },
+    errorMessage: {
+      401: MEMBER_NOT_FOUND_ERROR,
     },
   });
 };

--- a/src/domains/auth/datasources/signUpSource.ts
+++ b/src/domains/auth/datasources/signUpSource.ts
@@ -3,6 +3,7 @@ import { CONTENT_TYPE_JSON } from "@/lib/apis/constants/contentType";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 import ApiResponse from "@/lib/models/apiResponse";
 
+import { MEMBER_CONFLICT_ERROR } from "@/domains/auth/constants/errorMessage";
 import { SignUpReqDto } from "@/domains/auth/dtos/request/signUpReqDto";
 import { SignUpResDto } from "@/domains/auth/dtos/response/signUpResDto";
 
@@ -19,7 +20,7 @@ const signUpSource = async (body: SignUpReqDto): Promise<ApiResponse<SignUpResDt
       body: JSON.stringify(body),
     },
     errorMessage: {
-      403: "이미 등록된 계정이 있어요.",
+      409: MEMBER_CONFLICT_ERROR,
     },
   });
 

--- a/src/domains/auth/datasources/withdrawSource.ts
+++ b/src/domains/auth/datasources/withdrawSource.ts
@@ -1,6 +1,8 @@
 import { buildApiServerUrl } from "@/lib/utils/url";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
+import { MEMBER_NOT_FOUND_ERROR } from "@/domains/auth/constants/errorMessage";
+
 const withdrawSource = async (accessToken: string): Promise<void> => {
   const endpoint: string = "auth/withdraw";
 
@@ -11,6 +13,9 @@ const withdrawSource = async (accessToken: string): Promise<void> => {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
+    },
+    errorMessage: {
+      401: MEMBER_NOT_FOUND_ERROR,
     },
   });
 };

--- a/src/domains/insight/constants/errorMessage.ts
+++ b/src/domains/insight/constants/errorMessage.ts
@@ -1,0 +1,1 @@
+export const ALREADY_HARVESTED_INSIGHT_ERROR: string = "이미 수확한 수확물이에요.";

--- a/src/domains/insight/datasources/harvestInsightSource.ts
+++ b/src/domains/insight/datasources/harvestInsightSource.ts
@@ -2,6 +2,7 @@ import { buildApiServerUrl } from "@/lib/utils/url";
 import { CONTENT_TYPE_JSON } from "@/lib/apis/constants/contentType";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
+import { ALREADY_HARVESTED_INSIGHT_ERROR } from "@/domains/insight/constants/errorMessage";
 import { HarvestInsightReqDto } from "@/domains/insight/dtos/request/harvestInsightReqDto";
 
 const harvestInsightSource = async (body: HarvestInsightReqDto, accessToken: string): Promise<void> => {
@@ -18,7 +19,7 @@ const harvestInsightSource = async (body: HarvestInsightReqDto, accessToken: str
       body: JSON.stringify(body),
     },
     errorMessage: {
-      409: "이미 수확한 지식이에요.",
+      409: ALREADY_HARVESTED_INSIGHT_ERROR,
     },
   });
 };

--- a/src/domains/quiz/constants/errorMessage.ts
+++ b/src/domains/quiz/constants/errorMessage.ts
@@ -1,0 +1,2 @@
+export const INVALID_QUIZ_CHOICE_ERROR: string = "타작에 실패했어요. 다른 선택지를 한 번 더 살펴보는 건 어떨까요?";
+export const ALREADY_THRESHED_QUIZ_ERROR: string = "이미 타작한 타작물이에요.";

--- a/src/domains/quiz/datasources/threshQuizSource.ts
+++ b/src/domains/quiz/datasources/threshQuizSource.ts
@@ -2,6 +2,7 @@ import { buildApiServerUrl } from "@/lib/utils/url";
 import { CONTENT_TYPE_JSON } from "@/lib/apis/constants/contentType";
 import externalFetcher from "@/lib/apis/fetchers/externalFetcher";
 
+import { INVALID_QUIZ_CHOICE_ERROR, ALREADY_THRESHED_QUIZ_ERROR } from "@/domains/quiz/constants/errorMessage";
 import { ThreshQuizReqDto } from "@/domains/quiz/dtos/request/threshQuizReqDto";
 
 const threshQuizSource = async (body: ThreshQuizReqDto, accessToken: string): Promise<void> => {
@@ -18,8 +19,8 @@ const threshQuizSource = async (body: ThreshQuizReqDto, accessToken: string): Pr
       body: JSON.stringify(body),
     },
     errorMessage: {
-      400: "타작에 실패했어요. 다른 선택지를 한 번 더 살펴보는 건 어떨까요?",
-      409: "이미 타작한 수확물이에요.",
+      400: INVALID_QUIZ_CHOICE_ERROR,
+      409: ALREADY_THRESHED_QUIZ_ERROR,
     },
   });
 };

--- a/src/lib/errors/http/badRequestError.ts
+++ b/src/lib/errors/http/badRequestError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class BadRequestError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(400, "BadRequestError", errorMessage ?? "잘못된 요청입니다.");
+  constructor(message?: string) {
+    super(400, message ?? "잘못된 요청이에요.");
+    this.name = "BadRequestError";
   }
 }

--- a/src/lib/errors/http/conflictError.ts
+++ b/src/lib/errors/http/conflictError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class ConflictError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(409, "ConflictError", errorMessage ?? "이미 존재하는 리소스입니다.");
+  constructor(message?: string) {
+    super(409, message ?? "이미 존재하는 리소스에요.");
+    this.name = "ConflictError";
   }
 }

--- a/src/lib/errors/http/forbiddenError.ts
+++ b/src/lib/errors/http/forbiddenError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class ForbiddenError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(403, "ForbiddenError", errorMessage ?? "접근 권한이 없습니다.");
+  constructor(message?: string) {
+    super(403, message ?? "접근 권한이 없어요.");
+    this.name = "ForbiddenError";
   }
 }

--- a/src/lib/errors/http/httpError.ts
+++ b/src/lib/errors/http/httpError.ts
@@ -1,11 +1,9 @@
 export default abstract class HttpError extends Error {
-  statusCode: number;
-  errorType: string;
+  readonly statusCode: number;
 
-  constructor(statusCode: number, errorType: string, message: string) {
+  constructor(statusCode: number, message: string) {
     super(message);
     this.name = "HttpError";
     this.statusCode = statusCode;
-    this.errorType = errorType;
   }
 }

--- a/src/lib/errors/http/internalServerError.ts
+++ b/src/lib/errors/http/internalServerError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class InternalServerError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(500, "InternalServerError", errorMessage ?? "서버 요청 중 오류가 발생했습니다.");
+  constructor(message?: string) {
+    super(500, message ?? "서버 요청 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
+    this.name = "InternalServerError";
   }
 }

--- a/src/lib/errors/http/notFoundError.ts
+++ b/src/lib/errors/http/notFoundError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class NotFoundError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(404, "NotFoundError", errorMessage ?? "요청하신 리소스를 찾을 수 없습니다.");
+  constructor(message?: string) {
+    super(404, message ?? "리소스를 찾을 수 없어요.");
+    this.name = "NotFoundError";
   }
 }

--- a/src/lib/errors/http/unauthorizedError.ts
+++ b/src/lib/errors/http/unauthorizedError.ts
@@ -1,7 +1,8 @@
 import HttpError from "@/lib/errors/http/httpError";
 
 export default class UnauthorizedError extends HttpError {
-  constructor(errorMessage?: string) {
-    super(401, "UnauthorizedError", errorMessage ?? "인증이 필요합니다.");
+  constructor(message?: string) {
+    super(401, message ?? "인증이 필요해요.");
+    this.name = "UnauthorizedError";
   }
 }

--- a/src/lib/errors/networkError.ts
+++ b/src/lib/errors/networkError.ts
@@ -1,9 +1,0 @@
-/**
- * @deprecated
- */
-export default class NetworkError extends Error {
-  constructor() {
-    super("네트워크 에러가 발생했습니다.");
-    this.name = "NetworkError";
-  }
-}


### PR DESCRIPTION
## 📌 작업 개요

- 에러 클래스 property 수정 및 각 도메인 별 에러 메세지 상수화

## ✨ 주요 변경사항

- http error class의 errorType property 삭제 및 fallback 메세지 수정
- deprecated 되었던 NetworkError class 삭제
- 도메인 별 에러 메세지 상수화

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- 도메인 별 에러 메세지는 domains/<domain>/constants/errorMessage.ts에 정의

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
