### PR TITLE
chore: 코드 안정화

### DIFF
--- a/src/app/(service)/layout.tsx
+++ b/src/app/(service)/layout.tsx
@@ -20,7 +20,7 @@ const ServiceLayout = ({ children }: Readonly<ServiceLayoutProps>) => {
         <Main>{children}</Main>
       </main>
 
-      <footer>
+      <footer className="flex items-center justify-center h-40 bg-gray-100">
         <Footer />
       </footer>
     </div>

--- a/src/app/api/insight/status/[insightId]/route.ts
+++ b/src/app/api/insight/status/[insightId]/route.ts
@@ -6,7 +6,6 @@ import { parsePathParam } from "@/lib/utils/parser/api";
 import { stringToNumber } from "@/lib/utils/transformer/number";
 import ApiResponse from "@/lib/models/apiResponse";
 import { getAccessTokenFromCookie } from "@/lib/cookie/accessToken";
-import UnauthorizedError from "@/lib/errors/http/unauthorizedError";
 import NotFoundError from "@/lib/errors/http/notFoundError";
 
 import insightStatusSource from "@/domains/insight/datasources/insightStatusSource";
@@ -26,7 +25,7 @@ export const GET = async (_: Request, context: Params): Promise<NextResponse<Res
 
     const storedAccessToken: string | null = await getAccessTokenFromCookie();
     if (!storedAccessToken) {
-      throw new UnauthorizedError();
+      return NextResponse.json(success({ insightId, isHarvested: false }));
     }
 
     const apiResponse: ApiResponse<InsightStatusResDto> = await insightStatusSource(insightId, storedAccessToken);

--- a/src/app/api/quiz/status/[quizId]/route.ts
+++ b/src/app/api/quiz/status/[quizId]/route.ts
@@ -6,7 +6,6 @@ import { parsePathParam } from "@/lib/utils/parser/api";
 import { stringToNumber } from "@/lib/utils/transformer/number";
 import ApiResponse from "@/lib/models/apiResponse";
 import { getAccessTokenFromCookie } from "@/lib/cookie/accessToken";
-import UnauthorizedError from "@/lib/errors/http/unauthorizedError";
 import NotFoundError from "@/lib/errors/http/notFoundError";
 
 import quizStatusSource from "@/domains/quiz/datasources/quizStatusSource";
@@ -26,7 +25,7 @@ export const GET = async (_: Request, context: Params): Promise<NextResponse<Res
 
     const storedAccessToken: string | null = await getAccessTokenFromCookie();
     if (!storedAccessToken) {
-      throw new UnauthorizedError();
+      return NextResponse.json(success({ quizId, isThreshed: false }));
     }
 
     const apiResponse: ApiResponse<QuizStatusResDto> = await quizStatusSource(quizId, storedAccessToken);

--- a/src/components/organisms/SubInsightSection.tsx
+++ b/src/components/organisms/SubInsightSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { FiChevronDown, FiChevronUp } from "react-icons/fi";
-import { motion, AnimatePresence, easeOut } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 
 import { ICON_SIZE } from "@/lib/constants/ui";
 

--- a/src/components/organisms/layout/Footer.tsx
+++ b/src/components/organisms/layout/Footer.tsx
@@ -9,30 +9,28 @@ import Label1 from "@/components/atoms/typography/Label1";
 
 const Footer = () => {
   return (
-    <div className="flex items-center justify-center h-40 bg-gray-100">
-      <div className={clsx("flex flex-col justify-between w-full max-w-6xl h-full p-6", "md:flex-row md:items-center")}>
-        <div className="flex flex-col gap-6">
-          <Logo width={80} />
+    <div className={clsx("flex flex-col justify-between w-full max-w-6xl h-full p-6", "md:flex-row md:items-center")}>
+      <div className="flex flex-col gap-6">
+        <Logo width={80} />
 
-          <div className="flex flex-col">
-            <Caption1 text="Contact meerkatbrothers.team@gmail.com" styles={{ color: "text-gray-500", weight: "font-medium" }} />
+        <div className="flex flex-col">
+          <Caption1 text="Contact meerkatbrothers.team@gmail.com" styles={{ color: "text-gray-500", weight: "font-medium" }} />
 
-            <Caption1
-              text="Copyright © 2025 MeerkatBrothers. All rights reserved."
-              styles={{ color: "text-gray-500", weight: "font-medium" }}
-            />
-          </div>
+          <Caption1
+            text="Copyright © 2025 MeerkatBrothers. All rights reserved."
+            styles={{ color: "text-gray-500", weight: "font-medium" }}
+          />
         </div>
+      </div>
 
-        <div className={clsx("flex gap-4", "md:gap-8")}>
-          <a href={TERMS_OF_SERVICE_URL}>
-            <Label1 text="이용약관" styles={{ color: "text-gray-600" }} />
-          </a>
+      <div className={clsx("flex gap-4", "md:gap-8")}>
+        <a href={TERMS_OF_SERVICE_URL}>
+          <Label1 text="이용약관" styles={{ color: "text-gray-600" }} />
+        </a>
 
-          <a href={PRIVACY_POLICY_URL}>
-            <Label1 text="개인정보처리방침" styles={{ color: "text-gray-600" }} />
-          </a>
-        </div>
+        <a href={PRIVACY_POLICY_URL}>
+          <Label1 text="개인정보처리방침" styles={{ color: "text-gray-600" }} />
+        </a>
       </div>
     </div>
   );

--- a/src/domains/auth/hooks/useKakaoSignIn.ts
+++ b/src/domains/auth/hooks/useKakaoSignIn.ts
@@ -21,9 +21,9 @@ const useKakaoSignIn = ({ onSuccess, onError }: UseKakaoSignInParams) => {
 
   const { mutate: signIn } = useSignIn({
     onSuccess,
-    onError: (error, variables) => {
+    onError: (error, credentialForm) => {
       if (error instanceof ResultError && error.statusCode === 404) {
-        signUp(variables);
+        signUp(credentialForm);
       } else {
         onError?.(error);
       }
@@ -32,8 +32,8 @@ const useKakaoSignIn = ({ onSuccess, onError }: UseKakaoSignInParams) => {
 
   return useMutation({
     mutationFn: async (kakaoCode: string) => await getKakaoEmail(kakaoCode),
-    onSuccess: (_, variables) => {
-      const credentialForm: CredentialForm = { identifier: variables, loginPlatform: LOGIN_PLATFORM.KAKAO };
+    onSuccess: (_, kakaoCode) => {
+      const credentialForm: CredentialForm = { identifier: kakaoCode, loginPlatform: LOGIN_PLATFORM.KAKAO };
 
       signIn(credentialForm);
     },

--- a/src/domains/auth/hooks/useSignIn.ts
+++ b/src/domains/auth/hooks/useSignIn.ts
@@ -5,7 +5,7 @@ import { CredentialForm } from "@/domains/auth/models/fragments/credentialForm";
 
 interface UseSignInParams {
   onSuccess?: () => void;
-  onError?: (error: Error, variables: CredentialForm) => void;
+  onError?: (error: Error, credentialForm: CredentialForm) => void;
 }
 
 const useSignIn = ({ onSuccess, onError }: UseSignInParams) => {

--- a/src/domains/auth/hooks/useSignUp.ts
+++ b/src/domains/auth/hooks/useSignUp.ts
@@ -5,7 +5,7 @@ import { CredentialForm } from "@/domains/auth/models/fragments/credentialForm";
 
 interface UseSignUpParams {
   onSuccess?: () => void;
-  onError?: (error: Error, variables: CredentialForm) => void;
+  onError?: (error: Error, credentialForm: CredentialForm) => void;
 }
 
 const useSignUp = ({ onSuccess, onError }: UseSignUpParams) => {

--- a/src/domains/image/hooks/useUploadImage.ts
+++ b/src/domains/image/hooks/useUploadImage.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import uploadImage from "@/domains/image/usecases/uploadImage";
 
 interface UseUploadImageParams {
-  onSuccess?: (data: string) => void;
+  onSuccess?: (imageUrl: string) => void;
 }
 
 const useUploadImage = ({ onSuccess }: UseUploadImageParams) => {

--- a/src/domains/insight/hooks/useHarvestInsight.ts
+++ b/src/domains/insight/hooks/useHarvestInsight.ts
@@ -1,5 +1,7 @@
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 
+import PROGRESS_QUERY_KEYS from "@/domains/progress/constants/queryKey";
+
 import INSIGHT_QUERY_KEYS from "@/domains/insight/constants/queryKey";
 import harvestInsight from "@/domains/insight/usecases/harvestInsight";
 import { InsightStatus } from "@/domains/insight/models/insightStatus";
@@ -12,12 +14,13 @@ const useHarvestInsight = ({ onSuccess }: UseHarvestInsightParams) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (insightId: number) => harvestInsight(insightId),
-    onSuccess: (_, variables) => {
-      queryClient.setQueryData<InsightStatus>(INSIGHT_QUERY_KEYS.STATUS(variables), (prev) =>
+    mutationFn: async (insightId: number) => await harvestInsight(insightId),
+    onSuccess: (_, insightId) => {
+      queryClient.setQueryData<InsightStatus>(INSIGHT_QUERY_KEYS.STATUS(insightId), (prev) =>
         prev ? { ...prev, isHarvested: true } : prev,
       );
       queryClient.invalidateQueries({ queryKey: INSIGHT_QUERY_KEYS.HARVESTED });
+      queryClient.invalidateQueries({ queryKey: PROGRESS_QUERY_KEYS.MY });
 
       onSuccess?.();
     },

--- a/src/domains/profile/components/ProfileImageEditor.tsx
+++ b/src/domains/profile/components/ProfileImageEditor.tsx
@@ -14,7 +14,7 @@ interface ProfileImageEditorProps {
 }
 
 const ProfileImageEditor = ({ initialProfileImageUrl, onSelect }: ProfileImageEditorProps) => {
-  const imageUploaderRef = useRef<HTMLInputElement>(null);
+  const imageUploaderRef = useRef<HTMLInputElement | null>(null);
 
   return (
     <div>

--- a/src/domains/profile/components/UpdateProfileSection.tsx
+++ b/src/domains/profile/components/UpdateProfileSection.tsx
@@ -13,6 +13,7 @@ import UpdateProfileSectionSkeleton from "@/domains/profile/components/skeleton/
 
 import Caption1 from "@/components/atoms/typography/Caption1";
 import FormInput from "@/components/atoms/input/FormInput";
+import useAuthAction from "@/domains/auth/hooks/useAuthAction";
 
 const UpdateProfileSection = () => {
   const router = useRouter();
@@ -28,12 +29,14 @@ const UpdateProfileSection = () => {
     onSuccess: () => router.replace("/"),
   });
 
-  const handleWithdraw = (): void => {
-    const confirm: boolean = window.confirm("회원 탈퇴 시 농장 정보가 사라집니다.\n정말 탈퇴하시겠어요?");
-    if (confirm) {
-      withdraw();
-    }
-  };
+  const handleWithdraw = useAuthAction({
+    action: () => {
+      const confirm: boolean = window.confirm("회원 탈퇴 시 농장 정보가 사라집니다.\n정말 탈퇴하시겠어요?");
+      if (confirm) {
+        withdraw();
+      }
+    },
+  });
 
   if (isLoading) {
     return <UpdateProfileSectionSkeleton />;

--- a/src/domains/profile/hooks/useProfileForm.ts
+++ b/src/domains/profile/hooks/useProfileForm.ts
@@ -1,13 +1,13 @@
-import { useEffect, useState } from "react";
-
-import { ProfileForm } from "@/domains/profile/models/fragments/profileForm";
+import { useState, useEffect } from "react";
 
 import useUploadImage from "@/domains/image/hooks/useUploadImage";
+
+import { ProfileForm } from "@/domains/profile/models/fragments/profileForm";
 
 const useProfileForm = (initialProfileForm: ProfileForm) => {
   const [profileForm, setProfileForm] = useState<ProfileForm>(initialProfileForm);
 
-  const setNickname = (nickname: string) => setProfileForm({ ...profileForm, nickname });
+  const setNickname = (nickname: string): void => setProfileForm({ ...profileForm, nickname });
 
   const { mutate: uploadProfileImage } = useUploadImage({
     onSuccess: (profileImageUrl) => setProfileForm({ ...profileForm, profileImageUrl }),

--- a/src/domains/quiz/components/ThreshQuizButton.tsx
+++ b/src/domains/quiz/components/ThreshQuizButton.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import useAuthAction from "@/domains/auth/hooks/useAuthAction";
+
 import useQuizStatus from "@/domains/quiz/hooks/useQuizStatus";
 import useThreshQuiz from "@/domains/quiz/hooks/useThreshQuiz";
-import useAuthAction from "@/domains/auth/hooks/useAuthAction";
 
 import PrimaryButton from "@/components/atoms/button/PrimaryButton";
 import DotLoader from "@/components/atoms/DotLoader";

--- a/src/domains/quiz/hooks/useThreshQuiz.ts
+++ b/src/domains/quiz/hooks/useThreshQuiz.ts
@@ -2,11 +2,13 @@ import { useQueryClient, useMutation } from "@tanstack/react-query";
 
 import InvalidFormError from "@/lib/errors/invalidFormError";
 
+import INSIGHT_QUERY_KEYS from "@/domains/insight/constants/queryKey";
+
+import PROGRESS_QUERY_KEYS from "@/domains/progress/constants/queryKey";
+
 import QUIZ_QUERY_KEYS from "@/domains/quiz/constants/queryKey";
 import threshQuiz from "@/domains/quiz/usecases/threshQuiz";
 import { QuizStatus } from "@/domains/quiz/models/quizStatus";
-
-import INSIGHT_QUERY_KEYS from "@/domains/insight/constants/queryKey";
 
 interface ThreshQuizParams {
   quizId: number;
@@ -28,11 +30,10 @@ const useThreshQuiz = ({ onSuccess }: UseThreshQuizParams) => {
 
       await threshQuiz(quizId, choiceId);
     },
-    onSuccess: (_, variables) => {
-      queryClient.setQueryData<QuizStatus>(QUIZ_QUERY_KEYS.STATUS(variables.quizId), (prev) =>
-        prev ? { ...prev, isThreshed: true } : prev,
-      );
+    onSuccess: (_, params) => {
+      queryClient.setQueryData<QuizStatus>(QUIZ_QUERY_KEYS.STATUS(params.quizId), (prev) => (prev ? { ...prev, isThreshed: true } : prev));
       queryClient.invalidateQueries({ queryKey: INSIGHT_QUERY_KEYS.HARVESTED });
+      queryClient.invalidateQueries({ queryKey: PROGRESS_QUERY_KEYS.MY });
 
       onSuccess?.();
     },

--- a/src/lib/providers/QueryProvider.tsx
+++ b/src/lib/providers/QueryProvider.tsx
@@ -1,28 +1,43 @@
 "use client";
 
-import { useMemo, ReactNode } from "react";
+import { ReactNode, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { alertError } from "@/lib/utils/ui";
+import ResultError from "@/lib/errors/resultError";
 
-interface Props {
+interface QueryProviderProps {
   children: ReactNode;
 }
 
-const QueryProvider = ({ children }: Props) => {
-  const queryClient: QueryClient = useMemo(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          mutations: {
-            onError: (error) => alertError(error),
-          },
-        },
-      }),
-    [],
-  );
+const QueryProvider = ({ children }: QueryProviderProps) => {
+  const router = useRouter();
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  const queryClientRef = useRef<QueryClient | null>(null);
+
+  if (!queryClientRef.current) {
+    queryClientRef.current = new QueryClient();
+    queryClientRef.current.setDefaultOptions({
+      mutations: {
+        onError: (error) => {
+          if (error instanceof ResultError && error.statusCode === 401) {
+            alert("인증이 만료되었어요. 다시 로그인 해주세요.");
+
+            queryClientRef.current?.clear();
+
+            router.replace("/");
+
+            return;
+          }
+
+          alertError(error);
+        },
+      },
+    });
+  }
+
+  return <QueryClientProvider client={queryClientRef.current!}>{children}</QueryClientProvider>;
 };
 
 export default QueryProvider;


### PR DESCRIPTION
## 📌 작업 개요

- 비로그인시 수확 및 타작 상태 기본값 제공
- 토큰 중복 재발급 방지
- useMutation의 onSuccess 파라미터 이름 구체적으로 변경
- queryClient 메모이제이션 방식 변경
- 인증 만료 시 useQuery로 관리하는 캐시 초기화 후 메인페이지 이동

## ✨ 주요 변경사항

- 비로그인 유저 수확 및 타작 상태 요청 시 UnauthorizedError -> 기본값 제공으로 변경
- queryProvider로 제공하는 queryClient의 메모이제이션 방식을 useMemo -> useRef로 변경
- internalAuthFetcher에 reissueTokenPromise 변수를 통해 인증이 필요한 요청 병렬 요청 시 토큰 재발급은 1회만 되게 보장

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- X

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
