### PR TITLE
fix: 지식 목록에서 2줄 이상 지식 중앙화 되는 문제 해결

### DIFF
--- a/src/components/molecules/InsightPreviewCard.tsx
+++ b/src/components/molecules/InsightPreviewCard.tsx
@@ -12,7 +12,7 @@ interface InsightPreviewCardProps {
 
 const InsightPreviewCard = ({ insightPreview, onClick }: InsightPreviewCardProps) => {
   return (
-    <button className="flex flex-col items-start gap-1" onClick={() => onClick(insightPreview.id)}>
+    <button className="flex flex-col items-start text-start gap-1" onClick={() => onClick(insightPreview.id)}>
       <Heading1 text={insightPreview.subject} />
 
       <Label1 text={formatDateToYMD(insightPreview.publishedAt)} styles={{ color: "text-gray-300" }} />

--- a/src/components/molecules/MyInsightPreviewCard.tsx
+++ b/src/components/molecules/MyInsightPreviewCard.tsx
@@ -14,7 +14,7 @@ interface MyInsightPreviewCardProps {
 
 const MyInsightPreviewCard = ({ myInsightPreview, onClick }: MyInsightPreviewCardProps) => {
   return (
-    <button className="flex flex-col items-start gap-1" onClick={() => onClick(myInsightPreview.insightId)}>
+    <button className="flex flex-col items-start text-start gap-1" onClick={() => onClick(myInsightPreview.insightId)}>
       <div className="flex gap-1">
         <Heading1 text={myInsightPreview.subject} />
 


### PR DESCRIPTION
## 📌 작업 개요

- 지식 목록에서 2줄 이상 지식 중앙화 되는 문제 해결

## ✨ 주요 변경사항

- InsightPreviewCard와 MyInsightPreviewCard에 text-start를 주어 여러 줄의 지식이 왼쪽 정렬되게 변경

## 🧪 테스트 결과

- [ o ] 기능 정상 동작 확인
- [ o ] 에러 케이스 처리 확인
- [ - ] 빌드 및 배포 테스트 완료 (필요 시)

## 📋 참고사항

- X

## 🎯 체크리스트

- [ o ] 커밋 메시지 컨벤션 준수 (feat, fix, chore 등)
- [ o ] 불필요한 코드/주석 제거
- [ o ] PR 설명 작성
- [ o ] self-review 진행
